### PR TITLE
Integrate Casdoor login

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a Nuxt 3 application that displays articles from the ZZSZ‑YCT 
 - Dynamic background images pulled from the internet
 - Article list with lazy loading and detail pages
 - Markdown rendering with image sizing and KaTeX
-- Simple login menu powered by cookies
+- Login via Casdoor with cookie-based tokens
 - Custom 404 page
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "markdown-it": "^14.1.0",
     "markdown-it-imsize": "^2.0.1",
     "nuxt": "3.16.0",
+    "casdoor-js-sdk": "^0.16.0",
+    "jose": "^6.0.11",
     "pinia": "^2.3.0",
     "vue": "latest",
     "vue-router": "latest",

--- a/pages/callback.vue
+++ b/pages/callback.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import casdoor, { certificate } from '~/utils/casdoor'
+import { importSPKI, jwtVerify } from 'jose'
+import { useUserStore } from '~/stores/UserStore'
+
+const router = useRouter()
+const user = useUserStore()
+
+onMounted(async () => {
+  try {
+    const resp = await casdoor.exchangeForAccessToken()
+    const accessCookie = useCookie('access_token')
+    const refreshCookie = useCookie('refresh_token')
+    accessCookie.value = resp.access_token
+    refreshCookie.value = resp.refresh_token
+
+    const key = await importSPKI(certificate, 'RS256')
+    const { payload } = await jwtVerify(resp.access_token, key)
+    user.username = (payload as any).name ?? (payload as any).username
+    user.isLoggedIn = true
+  } catch (e) {
+    console.error(e)
+  }
+  router.replace('/')
+})
+</script>
+
+<template>
+  <v-container class="text-center py-10">
+    <v-progress-circular indeterminate />
+  </v-container>
+</template>
+
+<style scoped>
+</style>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
+import casdoor from '~/utils/casdoor'
 
+function login() {
+  casdoor.signin_redirect()
+}
 </script>
 
 <template>
-
+  <v-container class="text-center py-10">
+    <v-btn color="primary" @click="login">使用 Casdoor 登录</v-btn>
+  </v-container>
 </template>
 
 <style scoped>
-
 </style>

--- a/stores/UserStore.ts
+++ b/stores/UserStore.ts
@@ -1,10 +1,11 @@
 import type {jwtPayload} from "~/types/Authorization";
 import {jwtDecode} from "jwt-decode";
+import {refreshToken} from "~/utils/authorization";
 
 export const useUserStore = defineStore('userStore', {
     state: () => ({
-        isLoggedIn: true,
-        username: "username"
+        isLoggedIn: false,
+        username: ''
     }),
     actions: {
         logout() {
@@ -25,11 +26,10 @@ export const useUserStore = defineStore('userStore', {
             }
 
             if(refreshTokenCookie.value) {
-                this.username = jwtDecode<jwtPayload>(refreshTokenCookie.value).username
+                const payload = jwtDecode<jwtPayload>(refreshTokenCookie.value)
+                this.username = payload.name ?? payload.username
                 this.isLoggedIn = true
-                if(!accessTokenCookie.value) {
-                    refreshToken()
-                }
+                await refreshToken()
             }
         }
     }

--- a/utils/authorization.ts
+++ b/utils/authorization.ts
@@ -1,3 +1,30 @@
-export function refreshToken() {
+import casdoor from '~/utils/casdoor'
+import { jwtDecode } from 'jwt-decode'
 
+export async function refreshToken() {
+    const accessTokenCookie = useCookie('access_token')
+    const refreshTokenCookie = useCookie('refresh_token')
+
+    if(!refreshTokenCookie.value)
+        return
+
+    if(accessTokenCookie.value) {
+        try {
+            const exp = jwtDecode<{exp:number}>(accessTokenCookie.value).exp
+            if(exp * 1000 > Date.now() + 60000) {
+                return
+            }
+        } catch (_) {}
+    }
+
+    try {
+        const resp = await casdoor.refreshAccessToken(refreshTokenCookie.value)
+        accessTokenCookie.value = resp.access_token
+        if(resp.refresh_token)
+            refreshTokenCookie.value = resp.refresh_token
+    } catch (e) {
+        console.error(e)
+        accessTokenCookie.value = null
+        refreshTokenCookie.value = null
+    }
 }

--- a/utils/casdoor.ts
+++ b/utils/casdoor.ts
@@ -1,0 +1,40 @@
+import CasdoorSDK from 'casdoor-js-sdk'
+
+export const certificate = `-----BEGIN CERTIFICATE-----
+MIIE2TCCAsGgAwIBAgIDAeJAMA0GCSqGSIb3DQEBCwUAMCYxDjAMBgNVBAoTBWFk
+bWluMRQwEgYDVQQDDAtjZXJ0X3lidTVldDAeFw0yNTA1MDgxMjE2MTlaFw00NTA1
+MDgxMjE2MTlaMCYxDjAMBgNVBAoTBWFkbWluMRQwEgYDVQQDDAtjZXJ0X3lidTVl
+dDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKpE/pTl4H2s2Nan4UF2
+004MiWgWiO0r+HlMlICv78rXYM4AAe1eMnGw7P98DVvs6s+BgdUsDLuGHJDrs6Lr
+50pDXcXJX7XOI56S7gKIdYol9dSid6/fRpyFe2UTzt+UEmPNx974WRYUC8EFWdHc
+koz/0fKsb0uTHo93v6g/fb5rbxQzgaPzZDaqFgRmr4G3fypEmlDAeztlBac3uF4z
+M41LoNrKeznGHgHBsW1Wktw/NpVSG02KsfB/PyafudtRFhKna2IRIc46QbbOdJUJ
+GxceqMHTmpuAbNSEzB8eJTRcgL4rRSbGkiAEkEOrl5VkK8t9yMV+djNZSH6/s9RK
+zsb4QnSq/gdhly+ZorHqNfM92aKCEU89SkrOv6DmDJrDKfP6JjhIMlzCP9MfsBpg
+/racxdMY5tR6O0pGMP1Pt/yPdpxa1S8UboroZtap9ktse/xUo/VIesw1fpd5JlX2
+DPzIscg/kWNkGrzU+kvFmmknjm5mxVTV7qim6Z50XyqTDIhEOVRN9AeoGgMUKKAb
+GNTwrno/UhGQ5xpMXJjKxdC8mOBdmC0Q+nVuMEn9y7XYYRyItMgkFT65ZOC06tVw
+yqhrUdrmC+XV9yCkPuOtJYNsUu2AxVYwesC3aAKWtRhEHsfHGhOVby9nLcfFEruh
+4GDhKV1mDHyGhXgG6PTvT9NRAgMBAAGjEDAOMAwGA1UdEwEB/wQCMAAwDQYJKoZI
+hvcNAQELBQADggIBAB8OkAH9AuBImOH0Jve3GIe3YylDDIywKwCKMUGnJbRKwm94
+qRJms1jBYEjZsCSTK+2Rk9OlYe7LPBRnq85cBtJMYJGsIQUpV0/07mXkjx1digPA
+jCE7k+sL0RJBoku3GUfnfOqZ3LXzw3s22jJva0ye3h3E/6Dg2JoWv7PSqLlQWb2b
+6Gii9gcxLN5qGKXrY15DZ4f3DyIgisk5Xj1HYh2sT6UYU4XOvbZqo1hmDYbm7z4u
+qg5n5pgwqIX88TC+js/j4x4pNCP78dpEe6USaESbCbW1Z/JyPKhZrFT7YV+CMlWw
+giKuzyo35WVPOKX7yehaPZbKjdED+rUvTsGkXa2yQFjBJWSB+7PWkh9LMA5+KPAA
+iiUm6YOb+8lMo2gP7IW1cv0MJRLo8lJ93XERYX/ffRzP9aIfw930FN/t+wWnXAj6
+ZPsfheRNfrj6s4oALSMAKSf3chD7COQkTiUgByZnMdbLhy80CX6KuxrhoSiMrxaJ
+xBV5BvEJqTM9ZGJBhyJOMmEOmHXmS9Q5SiPtl3kbSQ9KYCLaHczooNvGn+QYubnt
+6H13fYi1mujqAyde1g+EA7uNn7mOrL9DZKU6kbpnD8fXUgiIJgArlqnH4ceRyGSC
+Z6Wq065aguY+cQlk54cbZkE1sfu4vuDPtzlAW8F4Es5mXEQFdpZGKbKMtYWQ
+-----END CERTIFICATE-----`
+
+const sdk = new CasdoorSDK({
+    serverUrl: 'https://user.zzszyct.xyz',
+    clientId: 'yctClassics',
+    appName: 'yctClassics',
+    organizationName: 'zzszyct',
+    redirectPath: '/callback'
+})
+
+export default sdk

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -1,4 +1,5 @@
 import type {Article} from "~/types/Article";
+import { refreshToken } from '~/utils/authorization'
 
 export async function fetchArticles() : Promise<Article[] | undefined> {
     refreshToken()


### PR DESCRIPTION
## Summary
- integrate Casdoor JS SDK and jose library
- implement Casdoor login page and callback handler
- verify tokens with provided certificate
- refresh tokens automatically when requesting articles
- update README with Casdoor login info
- fix import for Casdoor SDK

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c01d68a64832ab79473733401e597